### PR TITLE
🌎 Download PMC data from doi/pmid input

### DIFF
--- a/.changeset/strange-snakes-refuse.md
+++ b/.changeset/strange-snakes-refuse.md
@@ -1,0 +1,5 @@
+---
+'jats-fetch': patch
+---
+
+Download PMC data from doi/pmid input

--- a/packages/jats-fetch/src/download.ts
+++ b/packages/jats-fetch/src/download.ts
@@ -5,6 +5,8 @@ import type { ISession } from 'myst-cli-utils';
 import { isUrl, tic } from 'myst-cli-utils';
 import {
   constructJatsUrlFromPubMedCentral,
+  convertDOI2PMCID,
+  convertPMID2PMCID,
   getListingsFile,
   getPubMedJatsFromData,
   getPubMedJatsFromS3,
@@ -189,6 +191,21 @@ export async function jatsFetch(
     filename = `${foldername}.xml`;
     if (!output) {
       output = foldername;
+    }
+  }
+  if (input.match(/^[0-9]+$/)) {
+    // If input is a number, assume it is PMID and try to resolve PMC ID
+    const pmcid = await convertPMID2PMCID(session, input);
+    if (pmcid) {
+      session.log.debug(`Resolved input ${input} to PMC ID: ${pmcid}`);
+      input = pmcid;
+    }
+  }
+  if (doi.validate(input)) {
+    const pmcid = await convertDOI2PMCID(session, input);
+    if (pmcid) {
+      session.log.debug(`Resolved input ${input} to PMC ID: ${pmcid}`);
+      input = pmcid;
     }
   }
   if (!output) output = opts.data ? `${input}` : '.';

--- a/packages/jats-fetch/src/pubmed.ts
+++ b/packages/jats-fetch/src/pubmed.ts
@@ -140,6 +140,11 @@ export async function convertPMCID2DOI(session: ISession, pmcid: string, opts?: 
   return pmDoi;
 }
 
+export async function convertDOI2PMCID(session: ISession, input: string, opts?: ResolutionOptions) {
+  const pmDoi = await convertId(session, input, 'doi', 'pmcid', opts);
+  return pmDoi;
+}
+
 /**
  * Query NIH APIs for single DOI from PubMed ID
  */


### PR DESCRIPTION
This just provides a couple additional entries:
1. PMID input is converted to PMCID if possible
2. DOI input is converted to PMCID if possible (this enables full data download from DOI, where available)