### PR TITLE
📋 Prioritize custom resolver jats urls over pmc/doi

### DIFF
--- a/.changeset/selfish-poems-compete.md
+++ b/.changeset/selfish-poems-compete.md
@@ -1,0 +1,8 @@
+---
+'jats-convert': patch
+'jats-fetch': patch
+'jats-cli': patch
+'jats-xml': patch
+---
+
+Bump doi-utils version

--- a/.changeset/spotty-donuts-knock.md
+++ b/.changeset/spotty-donuts-knock.md
@@ -1,0 +1,5 @@
+---
+'jats-fetch': patch
+---
+
+Prioritize custom resolver jats urls over pmc/doi

--- a/package-lock.json
+++ b/package-lock.json
@@ -3906,9 +3906,10 @@
       }
     },
     "node_modules/doi-utils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/doi-utils/-/doi-utils-2.0.3.tgz",
-      "integrity": "sha512-vXWjB8Wz195m0PSw9jCwkCVBtPO+yIY/iPUQ1qTLD3GZ7alXreaoLKA3D4MAewPOBt+D8BU1LJiOF7WKpy9ifQ=="
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/doi-utils/-/doi-utils-2.0.6.tgz",
+      "integrity": "sha512-QkaDmWbr5lIugDgl9fCxDMos2OJJ9Rp4c9XB7wgRGm6hJQ+hgeqI78DqToU8+vmtU+1XAyyVYJoLZUAgBdsFtg==",
+      "license": "MIT"
     },
     "node_modules/dotenv": {
       "version": "16.4.5",
@@ -11744,7 +11745,7 @@
       "version": "1.0.16",
       "license": "MIT",
       "dependencies": {
-        "doi-utils": "^2.0.0",
+        "doi-utils": "^2.0.6",
         "fair-principles": "^2.0.0",
         "jats-convert": "^1.0.16",
         "jats-fetch": "^1.0.16",
@@ -11786,7 +11787,7 @@
       "version": "1.0.16",
       "license": "MIT",
       "dependencies": {
-        "doi-utils": "^2.0.3",
+        "doi-utils": "^2.0.6",
         "dotenv": "^16.4.5",
         "jats-fetch": "^1.0.16",
         "jats-tags": "^1.0.16",
@@ -11852,7 +11853,7 @@
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "3.686.0",
-        "doi-utils": "^2.0.0",
+        "doi-utils": "^2.0.6",
         "myst-cli-utils": "^2.0.11",
         "node-fetch": "^3.3.1",
         "xml-js": "^1.6.11"
@@ -11920,7 +11921,7 @@
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.10",
-        "doi-utils": "^2.0.3",
+        "doi-utils": "^2.0.6",
         "jats-tags": "^1.0.16",
         "jats-utils": "^1.0.16",
         "myst-cli-utils": "^2.0.11",

--- a/packages/jats-cli/package.json
+++ b/packages/jats-cli/package.json
@@ -43,7 +43,7 @@
     "url": "https://github.com/continuous-foundation/jats/issues"
   },
   "dependencies": {
-    "doi-utils": "^2.0.0",
+    "doi-utils": "^2.0.6",
     "fair-principles": "^2.0.0",
     "jats-convert": "^1.0.16",
     "jats-fetch": "^1.0.16",

--- a/packages/jats-convert/package.json
+++ b/packages/jats-convert/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/continuous-foundation/jats/issues"
   },
   "dependencies": {
-    "doi-utils": "^2.0.3",
+    "doi-utils": "^2.0.6",
     "dotenv": "^16.4.5",
     "jats-fetch": "^1.0.16",
     "jats-tags": "^1.0.16",

--- a/packages/jats-fetch/package.json
+++ b/packages/jats-fetch/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "3.686.0",
-    "doi-utils": "^2.0.0",
+    "doi-utils": "^2.0.6",
     "node-fetch": "^3.3.1",
     "myst-cli-utils": "^2.0.11",
     "xml-js": "^1.6.11"

--- a/packages/jats-xml/package.json
+++ b/packages/jats-xml/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "adm-zip": "^0.5.10",
-    "doi-utils": "^2.0.3",
+    "doi-utils": "^2.0.6",
     "jats-tags": "^1.0.16",
     "jats-utils": "^1.0.16",
     "myst-cli-utils": "^2.0.11",


### PR DESCRIPTION
This change shuffles around the order of `input url -> jats url` resolution. If the input url can be resolved both by (1) a `custom resolver` (e.g. it's a biorxiv url) and (2) pubmed, the jats from the custom resolver is preferred, as we know the "flavor" better, e.g. biorxiv figure filenames may be resolved to a biorxiv URL, whereas pubmed figure filenames will be unknown.

Previously, the pubmed jats was preferred; now the custom resolver jats is preferred.