### PR TITLE
🐕 Refactor ordering of attempted fetch methods

### DIFF
--- a/.changeset/polite-cameras-protect.md
+++ b/.changeset/polite-cameras-protect.md
@@ -1,0 +1,5 @@
+---
+'jats-fetch': patch
+---
+
+Refactor ordering of attempted fetch methods


### PR DESCRIPTION
After #67 - there was still the case where a DOI that resolved to (1) a URL that had a custom JATS resolver and (2) a PMCID with degraded JATS would prioritize (2). This was because in `jatsFetch` we were doing the `DOI -> PMC` conversion before even _attempting_ any resolving, so even though the DOI resolution was in the correct order, we only ever tried to resolve it as an already-converted PMC.

I think that's a pretty bad explanation... but hopefully the code changes make some sense. I'll leave comments.